### PR TITLE
[hotfix] remove specific sign in error msg

### DIFF
--- a/src/SignUpIn/SignIn.js
+++ b/src/SignUpIn/SignIn.js
@@ -29,7 +29,7 @@ class SignIn extends Component {
             })
             .catch(error => {
                 this.setState({
-                    error: error
+                    error: error.message
                 });
             });
     }
@@ -68,7 +68,7 @@ class SignIn extends Component {
                         {this.state.error && (
                             /* TODO: give better error msg */
                             <p className="sign-in-error">
-                                Unable to log in. {this.state.error}
+                                Unable to log in.
                             </p>
                         )}
                         <div className="login-button-wrapper">


### PR DESCRIPTION
Bug: rendering an object
Fix: remove the rendering. We actually don't want to display whatever error message firebase give us for security reasons.
Testing: log in with wrong log in info