### PR TITLE
[Hotfix] signout detach

### DIFF
--- a/src/PageContainer.js
+++ b/src/PageContainer.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import firebase from './FirebaseConfig.js';
 import { AccountType, PageContent } from './Enums.js';
 import NavBar from './PageLayout/Navigation/NavBar.js';
 import PageHeader from './PageLayout/PageHeader.js';
@@ -16,34 +15,14 @@ import Settings from './PageContent/Settings/Settings.js';
 
 class PageContainer extends Component {
     constructor(props) {
-        // Props: content, account
+        // Props: content, account, donatingAgency, signOut function
         super(props);
 
         this.state = {
             content: this.props.content,
-            donatingAgency: null
         };
-        this.navBarHandler = this.navBarHandler.bind(this);
-    }
 
-    componentDidMount() {
-        // grab the DA entity if user is DA member
-        if (
-            this.props.account.accountType ===
-            AccountType.DONATING_AGENCY_MEMBER
-        ) {
-            var daRef = firebase
-                .database()
-                .ref('donating_agencies')
-                .child(this.props.account.agency);
-            daRef.once('value').then(
-                function(daSnap) {
-                    this.setState({
-                        donatingAgency: daSnap.val()
-                    });
-                }.bind(this)
-            );
-        }
+        this.navBarHandler = this.navBarHandler.bind(this);
     }
 
     navBarHandler(e) {
@@ -57,16 +36,10 @@ class PageContainer extends Component {
             content: props.content
         });
     }
-    render() {
-        // wait for all data to come through
-        let ready = (this.props.account.accountType !== AccountType.DONATING_AGENCY_MEMBER ||
-            this.state.donatingAgency);
-        if (!ready) {
-            return null;
-        }
 
-        const { account } = this.props;
-        const { content, donatingAgency } = this.state;
+    render() {
+        const { account, donatingAgency } = this.props;
+        const { content } = this.state;
 
         let pageTitle;
         if (account.accountType === AccountType.DONATING_AGENCY_MEMBER) {
@@ -85,8 +58,10 @@ class PageContainer extends Component {
 
                 <NavBar
                     content={content}
-                    accountType={account.accountType}
+                    account={account}
+                    donatingAgency={donatingAgency}
                     handler={this.navBarHandler}
+                    signOut={this.props.signOut}
                 />
 
                 {content === PageContent.CALENDAR &&

--- a/src/PageContainer.js
+++ b/src/PageContainer.js
@@ -58,8 +58,7 @@ class PageContainer extends Component {
 
                 <NavBar
                     content={content}
-                    account={account}
-                    donatingAgency={donatingAgency}
+                    accountType={account.accountType}
                     handler={this.navBarHandler}
                     signOut={this.props.signOut}
                 />

--- a/src/PageLayout/Navigation/NavBar.js
+++ b/src/PageLayout/Navigation/NavBar.js
@@ -1,6 +1,5 @@
 // NavBar.js
 import React, { Component } from 'react';
-import { auth } from '../../FirebaseConfig.js';
 import { AccountType, PageContent } from '../../Enums.js';
 import NavBarItem from './NavBarItem';
 import './NavBar.css';
@@ -13,13 +12,20 @@ import assign_volunteer from '../../icons/assign_volunteer.svg';
 import signout from '../../icons/logout.svg';
 import { Link } from 'react-router-dom';
 
+
 class NavBar extends Component {
-    signOut(event) {
-        event.preventDefault();
-        auth.signOut();
-    }
+    // signOut(event) {
+    //     event.preventDefault();
+
+    //     // IMPORTANT: it's important to detach the listener to the account
+    //     // when signing out, since the App component will not unmount yet
+    //     // accountsRef.child(this.props.account.uid).off();
+    //     auth.signOut();
+    // }
 
     render() {
+        const accountType = this.props.account.accountType;
+
         return (
             <div className="navbar">
                 <Link to={'/calendar'} className="nav-link">
@@ -32,7 +38,7 @@ class NavBar extends Component {
                         handler={this.props.handler}
                     />
                 </Link>
-                {this.props.accountType === AccountType.DONATING_AGENCY_MEMBER && (
+                {accountType === AccountType.DONATING_AGENCY_MEMBER && (
                     <Link to={'/request-pickup'} className="nav-link">
                         <NavBarItem
                             highlighted={
@@ -45,7 +51,7 @@ class NavBar extends Component {
                         />
                     </Link>
                 )}
-                {this.props.accountType === AccountType.DELIVERER_GROUP && (
+                {accountType === AccountType.DELIVERER_GROUP && (
                     <Link to={'/assign-volunteers'} className="nav-link">
                         {' '}
                         <NavBarItem
@@ -92,7 +98,7 @@ class NavBar extends Component {
                 <NavBarItem
                     item={'signout'}
                     icon={signout}
-                    handler={this.signOut.bind(this)}
+                    handler={this.props.signOut}
                 />
             </div>
         );

--- a/src/PageLayout/Navigation/NavBar.js
+++ b/src/PageLayout/Navigation/NavBar.js
@@ -14,18 +14,7 @@ import { Link } from 'react-router-dom';
 
 
 class NavBar extends Component {
-    // signOut(event) {
-    //     event.preventDefault();
-
-    //     // IMPORTANT: it's important to detach the listener to the account
-    //     // when signing out, since the App component will not unmount yet
-    //     // accountsRef.child(this.props.account.uid).off();
-    //     auth.signOut();
-    // }
-
     render() {
-        const accountType = this.props.account.accountType;
-
         return (
             <div className="navbar">
                 <Link to={'/calendar'} className="nav-link">
@@ -38,7 +27,7 @@ class NavBar extends Component {
                         handler={this.props.handler}
                     />
                 </Link>
-                {accountType === AccountType.DONATING_AGENCY_MEMBER && (
+                {this.props.accountType === AccountType.DONATING_AGENCY_MEMBER && (
                     <Link to={'/request-pickup'} className="nav-link">
                         <NavBarItem
                             highlighted={
@@ -51,7 +40,7 @@ class NavBar extends Component {
                         />
                     </Link>
                 )}
-                {accountType === AccountType.DELIVERER_GROUP && (
+                {this.props.accountType === AccountType.DELIVERER_GROUP && (
                     <Link to={'/assign-volunteers'} className="nav-link">
                         {' '}
                         <NavBarItem


### PR DESCRIPTION
### Problem
We were not detaching listeners to accounts properly when signing out causing certain baffling behavior of getting switched back to previously logged-in account out of no where when performing certain db write actions.

### Changes
- Move **all** auth related and top-level account related listener handling into one place `App.js` for easier bookkeeping
  - move grabbing DA obj for DA Members from `PageContainer` to `App`
  - add listener to DA as well (eg change DA agency name in Settings wasn't reflected)
  - move `signOut` function from `NavBar` to `App`
- Detach listeners in `signOut` as well

### Testing
- The routine:
  1. Create delivery with DA
  2. Sign in and out with DG & RA
  3. Claim delivery as RA
  4. Check if I get switched to DG without doing anything else
- in general sign in and out and mess with stuff