### PR TITLE
[functions] Add To Donation Tally on Delivery Completion

### DIFF
--- a/functions/db/deliveries/onUpdate.f.js
+++ b/functions/db/deliveries/onUpdate.f.js
@@ -1,0 +1,70 @@
+const functions = require('firebase-functions');
+const enums = require('../../Enums.js');
+
+/*
+ * Listeners:
+ *
+ * LISTENER 1: Donation Tally
+ *  Trigger: delivery status becomes completed
+ *  Action: add food items to the system donation tally
+ */
+exports = module.exports = functions.database
+    .ref('deliveries/{dId}')
+    .onUpdate((change, context) => {
+        console.info('Delivery changed: ' + context.params.dId);
+
+        // LISTENER 1
+        if (deliveryCompleted(change)) {
+            return addToDonationTally(change.after);
+        }
+
+        console.info('Nothing was triggered.');
+        return null;
+    });
+
+// ----------------------- Listener 1 handlers -----------------------
+function deliveryCompleted(change) {
+    return change.before.child('status').val() !== enums.DeliveryStatus.COMPLETED &&
+        change.after.child('status').val() === enums.DeliveryStatus.COMPLETED;
+}
+
+function addToDonationTally(deliverySnap) {
+    console.info('Delivery completed: adding to donation tally..');
+    const tallyRef = deliverySnap.ref.parent.parent.child('donation_tally');
+    const delivery = deliverySnap.val();
+
+    if (!delivery.description || !delivery.description.foodItems) {
+        console.info('No food items in the delivery to add.');
+        return null;
+    }
+
+    let foodItems = delivery.description.foodItems;
+    let total = {};
+    // aggregate total donation by unit for this delivery
+    for (let food of foodItems) {
+        if (!total[food.unit]) {
+            total[food.unit] = 0;
+        }
+        total[food.unit] += parseInt(food.quantity);
+    }
+
+    // add to the donation tally using transactions
+    return tallyRef.transaction((tally) => {
+        if (tally) {
+            for (let unit in total) {
+                if (!tally[unit]) {
+                    tally[unit] = 0;
+                }
+                tally[unit] = parseInt(tally[unit]) + total[unit];
+            }
+        }
+        return tally;
+    }, (error, committed, snapshot) => {
+        if (committed) {
+            console.info('Total added: ', total);
+        } else if (error) {
+            console.error('Transaction failed abnormally!', error);
+        }
+    });
+}
+// ----------------------- End Listener 1 -----------------------

--- a/src/schema.txt
+++ b/src/schema.txt
@@ -437,3 +437,16 @@ delivery_indices: {
 
 -----------------------------------------------------
 
+DONATION TALLY ("/donation_tally/{umbrellaId}")
+// This only keeps the running total for the entire system to provide
+// fast query for the square space front page.
+// Additional on the fly calculation implementation is needed to get 
+// the analytical total for each agency.
+
+donation_tally: {
+	// one for each unit in Enums.FoodUnit
+	lb: 1000,
+	cases: 100,
+	loaves: 500,
+}
+


### PR DESCRIPTION
## Add To Donation Tally on Delivery Completion
Added server side listener that listens to deliveries (`/deliveries/{dId}`) and add the donations to the system's donation tally (`/donation_tally`) upon delivery completion (the delivery gone through the mobile delivery process and status changed to `completed`).

### Changes
- add documentation to `schema.txt`
- added `functions/db/deliveries/onUpdate.f.js`, the cloud function listener

### Test
- complete deliveries with donations and monitor db
